### PR TITLE
Include public CA certificates in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ RUN cd /go/src/${CODE} \
 ## Final image ## ------------------------------------------------------------
 #################
 
-FROM docker.io/busybox:latest
+FROM alpine:3
+
+RUN apk add --no-cache ca-certificates \
+    && update-ca-certificates
 
 COPY --from=kubedock /app /app
 


### PR DESCRIPTION
The busybox image does not contain public CA certs. When test-containers tries
to ping the container registry via containerized kubedock we get an error:
"x509: certificate signed by unknown authority"

Using a minimal Alpine image with the public CAs resolves this issue.