### PR TITLE
Allow specifying the User a container should run as

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -48,6 +48,7 @@ func init() {
 	serverCmd.PersistentFlags().DurationP("reapmax", "r", 60*time.Minute, "Reap all resources older than this time")
 	serverCmd.PersistentFlags().String("request-cpu", "", "Default k8s cpu resource request (optionally add ,limit)")
 	serverCmd.PersistentFlags().String("request-memory", "", "Default k8s memory resource request (optionally add ,limit)")
+	serverCmd.PersistentFlags().String("runas-user", "", "Numeric UID to run pods as (defaults to UID in image)")
 	serverCmd.PersistentFlags().Bool("lock", false, "Lock namespace for this instance")
 	serverCmd.PersistentFlags().Duration("lock-timeout", 15*time.Minute, "Max time trying to acquire namespace lock")
 	serverCmd.PersistentFlags().StringP("verbosity", "v", "1", "Log verbosity level")
@@ -69,6 +70,7 @@ func init() {
 	viper.BindPFlag("kubernetes.timeout", serverCmd.PersistentFlags().Lookup("timeout"))
 	viper.BindPFlag("kubernetes.request-cpu", serverCmd.PersistentFlags().Lookup("request-cpu"))
 	viper.BindPFlag("kubernetes.request-memory", serverCmd.PersistentFlags().Lookup("request-memory"))
+	viper.BindPFlag("kubernetes.runas-user", serverCmd.PersistentFlags().Lookup("runas-user"))
 	viper.BindPFlag("registry.inspector", serverCmd.PersistentFlags().Lookup("inspector"))
 	viper.BindPFlag("reaper.reapmax", serverCmd.PersistentFlags().Lookup("reapmax"))
 	viper.BindPFlag("lock.enabled", serverCmd.PersistentFlags().Lookup("lock"))
@@ -90,6 +92,7 @@ func init() {
 	viper.BindEnv("kubernetes.timeout", "TIME_OUT")
 	viper.BindEnv("kubernetes.request-cpu", "K8S_REQUEST_CPU")
 	viper.BindEnv("kubernetes.request-memory", "K8S_REQUEST_MEMORY")
+	viper.BindEnv("kubernetes.runas-user", "K8S_RUNAS_USER")
 	viper.BindEnv("kubernetes.timeout", "TIME_OUT")
 	viper.BindEnv("reaper.reapmax", "REAPER_REAPMAX")
 

--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -49,6 +49,11 @@ func (in *instance) StartContainer(tainr *types.Container) (DeployState, error) 
 		return DeployFailed, err
 	}
 
+	seccontext, err := tainr.GetPodSecurityContext()
+	if err != nil {
+		return DeployFailed, err
+	}
+
 	meta := metav1.ObjectMeta{
 		Namespace:   in.namespace,
 		Name:        tainr.ShortID,
@@ -71,6 +76,7 @@ func (in *instance) StartContainer(tainr *types.Container) (DeployState, error) 
 				Resources:       reqlimits,
 				ImagePullPolicy: pulpol,
 			}},
+			SecurityContext: &seccontext,
 		},
 	}
 

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -96,6 +96,11 @@ func (s *Server) getGinEngine() *gin.Engine {
 		klog.Infof("default memory request: %s", reqmem)
 	}
 
+	runasuid := viper.GetString("kubernetes.runas-user")
+	if runasuid != "" {
+		klog.Infof("default runas user: %s", runasuid)
+	}
+
 	pulpol := viper.GetString("kubernetes.pull-policy")
 	klog.Infof("default image pull policy: %s", pulpol)
 
@@ -105,6 +110,7 @@ func (s *Server) getGinEngine() *gin.Engine {
 		Inspector:     insp,
 		RequestCPU:    reqcpu,
 		RequestMemory: reqmem,
+		RunasUser:     runasuid,
 		PullPolicy:    pulpol,
 		PortForward:   pfwrd,
 		ReverseProxy:  revprox,

--- a/internal/server/routes/containers.go
+++ b/internal/server/routes/containers.go
@@ -34,6 +34,12 @@ func (cr *Router) ContainerCreate(c *gin.Context) {
 		in.Labels = map[string]string{}
 	}
 
+	// The User defined in HTTP request takes precedence over the CLI flag
+	// if not null.
+	if in.User == "" && cr.cfg.RunasUser != "" {
+		in.User = cr.cfg.RunasUser
+	}
+
 	if _, ok := in.Labels[types.LabelRequestCPU]; !ok && cr.cfg.RequestCPU != "" {
 		in.Labels[types.LabelRequestCPU] = cr.cfg.RequestCPU
 	}
@@ -57,6 +63,7 @@ func (cr *Router) ContainerCreate(c *gin.Context) {
 		Name:         in.Name,
 		Image:        in.Image,
 		Entrypoint:   in.Entrypoint,
+		User:         in.User,
 		Cmd:          in.Cmd,
 		Env:          in.Env,
 		ExposedPorts: in.ExposedPorts,

--- a/internal/server/routes/main.go
+++ b/internal/server/routes/main.go
@@ -20,6 +20,8 @@ type Config struct {
 	RequestCPU string
 	// RequestMemory contains an optional default k8s memory request
 	RequestMemory string
+	// RunasUser contains the UID to run pods as
+	RunasUser string
 	// PullPolicy contains the default pull policy for images
 	PullPolicy string
 	// PreArchive will enable copying files without starting containers

--- a/internal/server/routes/types.go
+++ b/internal/server/routes/types.go
@@ -10,6 +10,7 @@ type ContainerCreateRequest struct {
 	Entrypoint    []string               `json:"Entrypoint"`
 	Cmd           []string               `json:"Cmd"`
 	Env           []string               `json:"Env"`
+	User          string                 `json:"User"`
 	HostConfig    HostConfig             `json:"HostConfig"`
 	NetworkConfig NetworkingConfig       `json:"NetworkingConfig"`
 }


### PR DESCRIPTION
- Added a CLI flag that sets a default RunAsUser on managed pods, which
can be overridden by setting the User value when creating a container
via the Docker API.
- Implemented as a PodSecurityContext on the generated pod. This is
useful for running Kubedock against K8S clusters that require pods to
run as non-root