### PR TITLE
Use timeout config for the init container timeout

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -117,7 +117,7 @@ func (in *instance) StartContainer(tainr *types.Container) (DeployState, error) 
 	}
 
 	if tainr.HasVolumes() {
-		if err := in.copyVolumeFolders(tainr); err != nil {
+		if err := in.copyVolumeFolders(tainr, in.timeOut); err != nil {
 			return DeployFailed, err
 		}
 	}
@@ -497,8 +497,8 @@ func (in *instance) createConfigMapFromRaw(tainr *types.Container, files map[str
 // copyVolumeFolders will copy the configured volumes of the container to
 // the running init container, and signal the init container when finished
 // with copying.
-func (in *instance) copyVolumeFolders(tainr *types.Container) error {
-	if err := in.waitInitContainerRunning(tainr, "setup", 30); err != nil {
+func (in *instance) copyVolumeFolders(tainr *types.Container, wait int) error {
+	if err := in.waitInitContainerRunning(tainr, "setup", wait); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In some environments (like our overloaded EKS cluster) it might take more than the hardcoded 30 seconds timeout for the `setup` init container to start.

~~This change makes it configuration with a default 30s which should match the current behaviour if the parameter is not overwritten.~~

Simply use the `timeout` configuration parameter for the init timeout instead of the hardcoded 30s

