### PR TITLE
Return 404 if file does not exist on pod

### DIFF
--- a/internal/backend/main.go
+++ b/internal/backend/main.go
@@ -26,6 +26,7 @@ type Backend interface {
 	CopyFromContainer(*types.Container, string, io.Writer) error
 	CopyToContainer(*types.Container, io.Reader, string) error
 	GetFileModeInContainer(tainr *types.Container, path string) (fs.FileMode, error)
+	FileExistsInContainer(tainr *types.Container, path string) (bool, error)
 	ExecContainer(*types.Container, *types.Exec, io.Reader, io.Writer) (int, error)
 	GetLogs(*types.Container, bool, int, chan struct{}, io.Writer) error
 	GetImageExposedPorts(string) (map[string]struct{}, error)

--- a/internal/server/routes/common/archive.go
+++ b/internal/server/routes/common/archive.go
@@ -109,6 +109,17 @@ func HeadArchive(cr *ContextRouter, c *gin.Context) {
 		return
 	}
 
+	exists, err := cr.Backend.FileExistsInContainer(tainr, path)
+	if err != nil {
+		httputil.Error(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	if !exists {
+		httputil.Error(c, http.StatusNotFound, fmt.Errorf("file not found"))
+		return
+	}
+
 	mode, err := cr.Backend.GetFileModeInContainer(tainr, path)
 	if err != nil {
 		httputil.Error(c, http.StatusInternalServerError, err)
@@ -136,6 +147,17 @@ func GetArchive(cr *ContextRouter, c *gin.Context) {
 	path := c.Query("path")
 	if path == "" {
 		httputil.Error(c, http.StatusBadRequest, fmt.Errorf("missing required path parameter"))
+		return
+	}
+
+	exists, err := cr.Backend.FileExistsInContainer(tainr, path)
+	if err != nil {
+		httputil.Error(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	if !exists {
+		httputil.Error(c, http.StatusNotFound, fmt.Errorf("file not found"))
 		return
 	}
 


### PR DESCRIPTION
I've added a method for checking if file exists on pod before executing other command that will fail if file does not exist. This way we can return 404 Not Found error if file does not exist instead of 500.

I've had a problem with running elasticsearch testcontainers, because their [error handling](https://github.com/testcontainers/testcontainers-java/blob/d80ce6043fa4c4220532567490433d7824a2e77b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java#L142) only checks for 404 and not for 500. 


I've tested this with custom integration tests: [docker_test.zip](https://github.com/joyrex2001/kubedock/files/13363103/docker_test.zip).
