### PR TITLE
Implement tail on ContainerLogs

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -46,7 +46,8 @@ func (in *instance) StartContainer(tainr *types.Container) (DeployState, error) 
 		if klog.V(2) {
 			klog.Infof("container %s log output:", tainr.ShortID)
 			stop := make(chan struct{}, 1)
-			_ = in.GetLogs(tainr, false, 100, stop, os.Stderr)
+			count := int64(100)
+			_ = in.GetLogs(tainr, false, &count, stop, os.Stderr)
 			close(stop)
 		}
 		_ = in.cli.CoreV1().Pods(in.namespace).Delete(context.Background(), tainr.GetPodName(), metav1.DeleteOptions{})

--- a/internal/backend/logs.go
+++ b/internal/backend/logs.go
@@ -12,12 +12,11 @@ import (
 )
 
 // GetLogs will write the logs for given container to given writer.
-func (in *instance) GetLogs(tainr *types.Container, follow bool, count int, stop chan struct{}, w io.Writer) error {
-	tail := int64(count)
+func (in *instance) GetLogs(tainr *types.Container, follow bool, count *int64, stop chan struct{}, w io.Writer) error {
 	options := v1.PodLogOptions{
 		Container: "main",
 		Follow:    follow,
-		TailLines: &tail,
+		TailLines: count,
 	}
 
 	_, err := in.cli.CoreV1().Pods(in.namespace).Get(context.Background(), tainr.GetPodName(), metav1.GetOptions{})

--- a/internal/backend/logs_test.go
+++ b/internal/backend/logs_test.go
@@ -39,10 +39,11 @@ func TestGetLogs(t *testing.T) {
 		// },
 	}
 
+	count := int64(100)
 	for i, tst := range tests {
 		r, w := io.Pipe()
 		stop := make(chan struct{}, 1)
-		res := tst.kub.GetLogs(tst.in, false, 100, stop, w)
+		res := tst.kub.GetLogs(tst.in, false, &count, stop, w)
 		if (res != nil && !tst.out) || (res == nil && tst.out) {
 			t.Errorf("failed test %d - unexpected return value %s", i, res)
 		}

--- a/internal/backend/main.go
+++ b/internal/backend/main.go
@@ -31,7 +31,7 @@ type Backend interface {
 	GetFileModeInContainer(tainr *types.Container, path string) (fs.FileMode, error)
 	FileExistsInContainer(tainr *types.Container, path string) (bool, error)
 	ExecContainer(*types.Container, *types.Exec, io.Reader, io.Writer) (int, error)
-	GetLogs(*types.Container, bool, int, chan struct{}, io.Writer) error
+	GetLogs(*types.Container, bool, *int64, chan struct{}, io.Writer) error
 	GetImageExposedPorts(string) (map[string]struct{}, error)
 }
 

--- a/internal/server/routes/common/containers.go
+++ b/internal/server/routes/common/containers.go
@@ -228,7 +228,8 @@ func ContainerAttach(cr *ContextRouter, c *gin.Context) {
 	stop := make(chan struct{}, 1)
 	tainr.AddAttachChannel(stop)
 
-	if err := cr.Backend.GetLogs(tainr, true, 100, stop, out); err != nil {
+	count := int64(100)
+	if err := cr.Backend.GetLogs(tainr, true, &count, stop, out); err != nil {
 		klog.V(3).Infof("error retrieving logs: %s", err)
 	}
 


### PR DESCRIPTION
I hit a problem that, when using `testcontainers-rs`, and waiting for a specific message to appear in the logs, the container would never become ready.

The problem is related to the fact that the if a container produces a lot of lines, the actual line could have appeared before the last 100 lines that are returned, this PR implements the handling of the `tail` parameter.

If the parameter is non numeric, `all` is assumed, otherwise a number is assumed. If negative all is returned (as per spec).

 