### PR TITLE
Implement support for timestamps and since

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -47,7 +47,8 @@ func (in *instance) StartContainer(tainr *types.Container) (DeployState, error) 
 			klog.Infof("container %s log output:", tainr.ShortID)
 			stop := make(chan struct{}, 1)
 			count := int64(100)
-			_ = in.GetLogs(tainr, false, &count, stop, os.Stderr)
+			logOpts := LogOptions{TailLines: &count}
+			_ = in.GetLogs(tainr, &logOpts, stop, os.Stderr)
 			close(stop)
 		}
 		_ = in.cli.CoreV1().Pods(in.namespace).Delete(context.Background(), tainr.GetPodName(), metav1.DeleteOptions{})

--- a/internal/backend/logs.go
+++ b/internal/backend/logs.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"io"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -11,13 +12,21 @@ import (
 	"github.com/joyrex2001/kubedock/internal/util/ioproxy"
 )
 
+// LogOptions describe the supported log options
+type LogOptions struct {
+	// Keep connection after returning logs.
+	Follow bool
+	// Only return logs since this time, as a UNIX timestamp
+	SinceTime *time.Time
+	// Add timestamps to every log line
+	Timestamps bool
+	// Number of lines to show from the end of the logs
+	TailLines *int64
+}
+
 // GetLogs will write the logs for given container to given writer.
-func (in *instance) GetLogs(tainr *types.Container, follow bool, count *int64, stop chan struct{}, w io.Writer) error {
-	options := v1.PodLogOptions{
-		Container: "main",
-		Follow:    follow,
-		TailLines: count,
-	}
+func (in *instance) GetLogs(tainr *types.Container, opts *LogOptions, stop chan struct{}, w io.Writer) error {
+	options := newPodLogOptions(opts)
 
 	_, err := in.cli.CoreV1().Pods(in.namespace).Get(context.Background(), tainr.GetPodName(), metav1.GetOptions{})
 	if err != nil {
@@ -33,7 +42,7 @@ func (in *instance) GetLogs(tainr *types.Container, follow bool, count *int64, s
 
 	stopL := make(chan struct{}, 1)
 
-	if follow {
+	if opts.Follow {
 		go func() {
 			<-stop
 			stopL <- struct{}{}
@@ -61,7 +70,7 @@ func (in *instance) GetLogs(tainr *types.Container, follow bool, count *int64, s
 			return err
 		}
 		if n == 0 {
-			if !follow {
+			if !opts.Follow {
 				break
 			}
 			continue
@@ -73,4 +82,20 @@ func (in *instance) GetLogs(tainr *types.Container, follow bool, count *int64, s
 	}
 
 	return nil
+}
+
+func newPodLogOptions(opts *LogOptions) v1.PodLogOptions {
+	var sinceTime *metav1.Time = nil
+	if opts.SinceTime != nil {
+		t := metav1.NewTime(*opts.SinceTime)
+		sinceTime = &t
+	}
+
+	return v1.PodLogOptions{
+		Container:  "main",
+		Follow:     opts.Follow,
+		TailLines:  opts.TailLines,
+		SinceTime:  sinceTime,
+		Timestamps: opts.Timestamps,
+	}
 }

--- a/internal/backend/logs_test.go
+++ b/internal/backend/logs_test.go
@@ -40,10 +40,11 @@ func TestGetLogs(t *testing.T) {
 	}
 
 	count := int64(100)
+	logOpts := LogOptions{TailLines: &count}
 	for i, tst := range tests {
 		r, w := io.Pipe()
 		stop := make(chan struct{}, 1)
-		res := tst.kub.GetLogs(tst.in, false, &count, stop, w)
+		res := tst.kub.GetLogs(tst.in, &logOpts, stop, w)
 		if (res != nil && !tst.out) || (res == nil && tst.out) {
 			t.Errorf("failed test %d - unexpected return value %s", i, res)
 		}

--- a/internal/backend/main.go
+++ b/internal/backend/main.go
@@ -31,7 +31,7 @@ type Backend interface {
 	GetFileModeInContainer(tainr *types.Container, path string) (fs.FileMode, error)
 	FileExistsInContainer(tainr *types.Container, path string) (bool, error)
 	ExecContainer(*types.Container, *types.Exec, io.Reader, io.Writer) (int, error)
-	GetLogs(*types.Container, bool, *int64, chan struct{}, io.Writer) error
+	GetLogs(*types.Container, *LogOptions, chan struct{}, io.Writer) error
 	GetImageExposedPorts(string) (map[string]struct{}, error)
 }
 

--- a/internal/server/routes/common/containers.go
+++ b/internal/server/routes/common/containers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"k8s.io/klog"
 
+	"github.com/joyrex2001/kubedock/internal/backend"
 	"github.com/joyrex2001/kubedock/internal/events"
 	"github.com/joyrex2001/kubedock/internal/server/httputil"
 )
@@ -229,7 +230,8 @@ func ContainerAttach(cr *ContextRouter, c *gin.Context) {
 	tainr.AddAttachChannel(stop)
 
 	count := int64(100)
-	if err := cr.Backend.GetLogs(tainr, true, &count, stop, out); err != nil {
+	logOpts := backend.LogOptions{Follow: true, TailLines: &count}
+	if err := cr.Backend.GetLogs(tainr, &logOpts, stop, out); err != nil {
 		klog.V(3).Infof("error retrieving logs: %s", err)
 	}
 


### PR DESCRIPTION
This PR implements the `since` and `timestamps` query parameters.

I have left the `until` not implemented, because the API version that the kubedoc reports does not support it, and also because that would require manual filtering of the logs, as the underlaying k8s API does not support it either.

This PR makes kubedoc to support  this kind of use cases:

```
❯ DOCKER_HOST=localhost:2475 docker logs ea7cfd449f27 --timestamps --since=15s -n3
2023-12-21T14:41:16.669501622Z ok
2023-12-21T14:41:17.169580367Z ok
2023-12-21T14:41:17.669646665Z ok
```

