### PR TITLE
Fix tailing logs with negative limits

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -46,7 +46,7 @@ func (in *instance) StartContainer(tainr *types.Container) (DeployState, error) 
 		if klog.V(2) {
 			klog.Infof("container %s log output:", tainr.ShortID)
 			stop := make(chan struct{}, 1)
-			count := int64(100)
+			count := uint64(100)
 			logOpts := LogOptions{TailLines: &count}
 			_ = in.GetLogs(tainr, &logOpts, stop, os.Stderr)
 			close(stop)

--- a/internal/backend/logs.go
+++ b/internal/backend/logs.go
@@ -21,7 +21,7 @@ type LogOptions struct {
 	// Add timestamps to every log line
 	Timestamps bool
 	// Number of lines to show from the end of the logs
-	TailLines *int64
+	TailLines *uint64
 }
 
 // GetLogs will write the logs for given container to given writer.
@@ -91,10 +91,16 @@ func newPodLogOptions(opts *LogOptions) v1.PodLogOptions {
 		sinceTime = &t
 	}
 
+	var tailLines *int64 = nil
+	if opts.TailLines != nil {
+		l := int64(*opts.TailLines)
+		tailLines = &l
+	}
+
 	return v1.PodLogOptions{
 		Container:  "main",
 		Follow:     opts.Follow,
-		TailLines:  opts.TailLines,
+		TailLines:  tailLines,
 		SinceTime:  sinceTime,
 		Timestamps: opts.Timestamps,
 	}

--- a/internal/server/routes/common/containers.go
+++ b/internal/server/routes/common/containers.go
@@ -229,7 +229,7 @@ func ContainerAttach(cr *ContextRouter, c *gin.Context) {
 	stop := make(chan struct{}, 1)
 	tainr.AddAttachChannel(stop)
 
-	count := int64(100)
+	count := uint64(100)
 	logOpts := backend.LogOptions{Follow: true, TailLines: &count}
 	if err := cr.Backend.GetLogs(tainr, &logOpts, stop, out); err != nil {
 		klog.V(3).Infof("error retrieving logs: %s", err)

--- a/internal/server/routes/common/logs.go
+++ b/internal/server/routes/common/logs.go
@@ -36,7 +36,7 @@ func ContainerLogs(cr *ContextRouter, c *gin.Context) {
 	w.WriteHeader(http.StatusOK)
 
 	follow, _ := strconv.ParseBool(c.Query("follow"))
-	tailLines, _ := parseInt64(c.Query("tail"))
+	tailLines, _ := parseUint64(c.Query("tail"))
 	sinceTime, _ := parseUnix(c.Query("since"))
 	timestamps, _ := strconv.ParseBool(c.Query("timestamps"))
 
@@ -74,9 +74,9 @@ func ContainerLogs(cr *ContextRouter, c *gin.Context) {
 	}
 }
 
-// Parses the input expecting an int64 number as a string.
-func parseInt64(input string) (*int64, error) {
-	num, err := strconv.ParseInt(input, 10, 32)
+// Parses the input expecting an uint64 number as a string.
+func parseUint64(input string) (*uint64, error) {
+	num, err := strconv.ParseUint(input, 10, 32)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR changes the type used the tail limit, so that negative numbers are treated as no limit, instead of crashing.
 
This hopefully fixes an issue reported here: https://github.com/joyrex2001/kubedock/issues/77