### PR TITLE
Fix Add Volumes and Pre Archives Test

### DIFF
--- a/internal/backend/deploy_test.go
+++ b/internal/backend/deploy_test.go
@@ -622,6 +622,12 @@ func TestAddVolumesAndPreArchives(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no error but got: %v", err)
 		}
+
+		err = kub.addPreArchives(tst.in, pod)
+		if err != nil {
+			t.Errorf("expected no error but got: %v", err)
+		}
+
 		count := len(pod.Spec.Volumes)
 		if count != tst.count {
 			t.Errorf("failed test %d - expected %d volume, but got %d", i, tst.count, count)


### PR DESCRIPTION
This fixes the test of my last pull request. I was playing around with calling `kub.addPreArchives(tst.in, pod)` before and after `kub.addVolumes(tst.in, pod)` to see if it makes a difference. It does not, but then I forgot to add the call `kub.addPreArchives(tst.in, pod)` altogether (which is of course needed to test the combination) and forgot to run the tests again🙈.

Sorry about that. Fortunately, the CI runs the tests again to catch exactly such errors of my own laziness.