### PR TITLE
fix: honor hostname setting in containers

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -285,7 +285,6 @@ func (in *instance) getServices(tainr *types.Container) []corev1.Service {
 			klog.Infof("ignoring network alias %s, invalid name", alias)
 			continue
 		}
-		// TODO remove
 		klog.Infof("Creating service %s", alias)
 		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{

--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -87,6 +88,9 @@ func (in *instance) startContainer(tainr *types.Container) (DeployState, error) 
 
 	pod.Spec.Containers = []corev1.Container{container}
 
+	if tainr.Hostname != "" {
+		pod.Spec.Hostname = tainr.Hostname
+	}
 	pod.Spec.ServiceAccountName = tainr.GetServiceAccountName(pod.Spec.ServiceAccountName)
 	pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 
@@ -267,11 +271,22 @@ func (in *instance) getServices(tainr *types.Container) []corev1.Service {
 		return svcs
 	}
 	valid := regexp.MustCompile("^[a-z]([-a-z0-9]*[a-z0-9])?$")
+
+	// gather all aliases, ignore duplicates, convert to lower case
+	aliases := make(map[string]bool)
+	if tainr.Hostname != "" {
+		aliases[strings.ToLower(tainr.Hostname)] = true
+	}
 	for _, alias := range tainr.NetworkAliases {
+		aliases[strings.ToLower(alias)] = true
+	}
+	for alias := range aliases {
 		if ok := valid.MatchString(alias); !ok {
 			klog.Infof("ignoring network alias %s, invalid name", alias)
 			continue
 		}
+		// TODO remove
+		klog.Infof("Creating service %s", alias)
 		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   in.namespace,

--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -285,7 +285,7 @@ func (in *instance) getServices(tainr *types.Container) []corev1.Service {
 			klog.Infof("ignoring network alias %s, invalid name", alias)
 			continue
 		}
-		klog.Infof("Creating service %s", alias)
+		klog.V(4).Infof("Creating service %s", alias)
 		svc := corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:   in.namespace,

--- a/internal/model/types/container.go
+++ b/internal/model/types/container.go
@@ -21,6 +21,7 @@ type Container struct {
 	ID             string
 	ShortID        string
 	Name           string
+	Hostname       string
 	Image          string
 	Labels         map[string]string
 	Entrypoint     []string

--- a/internal/server/routes/docker/containers.go
+++ b/internal/server/routes/docker/containers.go
@@ -80,6 +80,7 @@ func ContainerCreate(cr *common.ContextRouter, c *gin.Context) {
 
 	tainr := &types.Container{
 		Name:         in.Name,
+		Hostname:     in.Hostname,
 		Image:        in.Image,
 		Entrypoint:   in.Entrypoint,
 		Cmd:          in.Cmd,

--- a/internal/server/routes/docker/types.go
+++ b/internal/server/routes/docker/types.go
@@ -4,6 +4,7 @@ package docker
 // is used for the /container/create post endpoint.
 type ContainerCreateRequest struct {
 	Name          string                 `json:"name"`
+	Hostname      string                 `json:"Hostname"`
 	Image         string                 `json:"image"`
 	ExposedPorts  map[string]interface{} `json:"ExposedPorts"`
 	Labels        map[string]string      `json:"Labels"`


### PR DESCRIPTION
1. when a hostname is specified, kubedock should also create a service for that hostname
2. when a hostname is specified, the pod definition now has pod.spec.hostname set to the hostname.
3. dealing with duplicates in aliases and hostname and also converting the hostname and aliases to lower case