### PR TITLE
Support compressed tar at PutContainerArchive operation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/docker/docker-credential-helpers v0.8.2 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,9 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
+github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -192,8 +195,10 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS5BM=
 github.com/klauspost/cpuid/v2 v2.2.8/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
@@ -316,6 +321,7 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=

--- a/internal/util/tar/concatreader.go
+++ b/internal/util/tar/concatreader.go
@@ -1,0 +1,31 @@
+package tar
+
+import "io"
+
+// ConcatReader is an [io.Reader] that first returns data from a wrapped bytes slice and then continues to return data
+// from a wrapped [io.Reader]
+type ConcatReader struct {
+	data   []byte
+	offset int
+	reader io.Reader
+}
+
+func NewConcatReader(data []byte, reader io.Reader) *ConcatReader {
+	return &ConcatReader{data: data, reader: reader}
+}
+
+func (r *ConcatReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.data) {
+		n, err := r.reader.Read(p)
+		r.offset += n
+		return n, err
+	}
+	n := copy(p, r.data[r.offset:])
+	r.offset += n
+	return n, nil
+}
+
+// ReadBytes returns the number of read bytes
+func (r *ConcatReader) ReadBytes() int {
+	return r.offset
+}

--- a/internal/util/tar/concatreader_test.go
+++ b/internal/util/tar/concatreader_test.go
@@ -1,0 +1,42 @@
+package tar
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"testing"
+)
+
+func TestConcatReader(t *testing.T) {
+	data := make([]byte, 10)
+	_, err := rand.Read(data)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// when bytes slice is empty
+	reader := NewConcatReader(nil, bytes.NewReader(data))
+	actual, err := io.ReadAll(reader)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if !bytes.Equal(data, actual) {
+		t.Errorf("data mismatch: expected %s, got %s", string(data), string(actual))
+	}
+	if reader.ReadBytes() != len(data) {
+		t.Errorf("read bytes mismatch: expected %d, got %d", len(data), reader.ReadBytes())
+	}
+
+	// when bytes slice is not empty
+	reader = NewConcatReader(data[:4], bytes.NewReader(data[4:]))
+	actual, err = io.ReadAll(reader)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if !bytes.Equal(data, actual) {
+		t.Errorf("data mismatch: expected %s, got %s", string(data), string(actual))
+	}
+	if reader.ReadBytes() != len(data) {
+		t.Errorf("read bytes mismatch: expected %d, got %d", len(data), reader.ReadBytes())
+	}
+}

--- a/internal/util/tar/reader.go
+++ b/internal/util/tar/reader.go
@@ -1,0 +1,108 @@
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"github.com/ulikunitz/xz"
+	"io"
+)
+
+// Reader is able to read tar archive uncompressed, compressed with gzip, xz, or bzip2
+type Reader struct {
+	concatReader *ConcatReader
+	tr           *tar.Reader
+	close        func() error
+}
+
+func NewReader(reader io.Reader) (r *Reader, err error) {
+	first5Bytes := make([]byte, 5)
+	_, err = reader.Read(first5Bytes)
+	if err != nil {
+		if err != io.EOF {
+			return
+		}
+	}
+	r = &Reader{
+		concatReader: NewConcatReader(first5Bytes, reader),
+	}
+	switch detectCompressionType(first5Bytes) {
+	case "gzip":
+		zr, err := gzip.NewReader(r.concatReader)
+		if err != nil {
+			return nil, err
+		}
+		r.close = zr.Close
+		r.tr = tar.NewReader(zr)
+	case "bzip2":
+		r.tr = tar.NewReader(bzip2.NewReader(r.concatReader))
+	case "xz":
+		xzr, err := xz.NewReader(r.concatReader)
+		if err != nil {
+			return nil, err
+		}
+		r.tr = tar.NewReader(xzr)
+	default:
+		r.tr = tar.NewReader(r.concatReader)
+	}
+	return r, nil
+}
+
+// Next advances to the next entry in the tar archive.
+// The Header.Size determines how many bytes can be read for the next file.
+// Any remaining data in the current file is automatically discarded.
+// At the end of the archive, Next returns the error io.EOF.
+//
+// If Next encounters a non-local name (as defined by [filepath.IsLocal])
+// and the GODEBUG environment variable contains `tarinsecurepath=0`,
+// Next returns the header with an [ErrInsecurePath] error.
+// A future version of Go may introduce this behavior by default.
+// Programs that want to accept non-local names can ignore
+// the [ErrInsecurePath] error and use the returned header.
+func (r *Reader) Next() (*tar.Header, error) {
+	return r.tr.Next()
+}
+
+// Read reads from the current file in the tar archive.
+// It returns (0, io.EOF) when it reaches the end of that file,
+// until [Next] is called to advance to the next file.
+//
+// If the current file is sparse, then the regions marked as a hole
+// are read back as NUL-bytes.
+//
+// Calling Read on special types like [TypeLink], [TypeSymlink], [TypeChar],
+// [TypeBlock], [TypeDir], and [TypeFifo] returns (0, [io.EOF]) regardless of what
+// the [Header.Size] claims.
+func (r *Reader) Read(p []byte) (int, error) {
+	return r.tr.Read(p)
+}
+
+// ReadBytes returns the number of read bytes
+func (r *Reader) ReadBytes() int {
+	return r.concatReader.ReadBytes()
+}
+
+func (r *Reader) Close() error {
+	if r.close != nil {
+		return r.close()
+	}
+	return nil
+}
+
+// detectCompressionType determines the compression type based on magic bytes.
+func detectCompressionType(data []byte) string {
+	if len(data) < 3 {
+		return "unknown"
+	}
+	switch {
+	case bytes.HasPrefix(data, []byte{0x1f, 0x8b}): // Gzip
+		return "gzip"
+	case bytes.HasPrefix(data, []byte{0xfd, '7', 'z', 'X', 'Z'}): // XZ
+		return "xz"
+	case bytes.HasPrefix(data, []byte{'B', 'Z', 'h'}): // Bzip2
+		return "bzip2"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/util/tar/reader_test.go
+++ b/internal/util/tar/reader_test.go
@@ -1,0 +1,120 @@
+package tar
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/dsnet/compress/bzip2"
+	"github.com/ulikunitz/xz"
+	"io"
+	"testing"
+)
+
+func TestReader(t *testing.T) {
+	// write tar archive
+	buf := new(bytes.Buffer)
+	tw := tar.NewWriter(buf)
+	filename := "some.file"
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     filename,
+		Size:     10,
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	data := make([]byte, 10)
+	_, err := rand.Read(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	archive := make([]byte, buf.Len())
+	copy(archive, buf.Bytes())
+
+	// read uncompressed archive
+	tr, err := NewReader(bytes.NewReader(archive))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assertTarContent(t, tr, filename, data)
+
+	// read gzip archive
+	buf.Reset()
+	gz := gzip.NewWriter(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, err = gz.Write(archive); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tr, err = NewReader(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assertTarContent(t, tr, filename, data)
+
+	// read bzip2 archive
+	buf.Reset()
+	bz, err := bzip2.NewWriter(buf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, err = bz.Write(archive); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := bz.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tr, err = NewReader(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assertTarContent(t, tr, filename, data)
+
+	// read xz archive
+	buf.Reset()
+	xzw, err := xz.NewWriter(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if _, err = xzw.Write(archive); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err = xzw.Close(); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	tr, err = NewReader(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assertTarContent(t, tr, filename, data)
+}
+
+func assertTarContent(t *testing.T, tr *Reader, filename string, fileContent []byte) {
+	t.Helper()
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if hdr.Name != filename {
+		t.Errorf("filename mismatch: expected %s, got %s", filename, hdr.Name)
+	}
+	data := make([]byte, hdr.Size)
+	_, err = tr.Read(data)
+	if err != nil && err != io.EOF {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if !bytes.Equal(data, fileContent) {
+		t.Errorf("fileContent mismatch: expected %s, got %s", spew.Sdump(fileContent), spew.Sdump(data))
+	}
+}

--- a/internal/util/tar/tar.go
+++ b/internal/util/tar/tar.go
@@ -89,7 +89,10 @@ func GetTargetFileNames(dst string, archive io.Reader) ([]string, error) {
 // getTargets will return all given asset names of type (dir/file).
 func getTargets(dst string, archive io.Reader, typ byte) ([]string, error) {
 	res := []string{}
-	tr := tar.NewReader(archive)
+	tr, err := NewReader(archive)
+	if err != nil {
+		return nil, err
+	}
 	for {
 		header, err := tr.Next()
 		switch {


### PR DESCRIPTION
Previously, the PutContainerArchive handler only supported uncompressed tar archives. This PR adds support for gzip, xz, and bzip2 compressed archives.