### PR TITLE
issue-110 Optional disabling of services to allow network flattening

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -62,6 +62,7 @@ func init() {
 	serverCmd.PersistentFlags().Bool("port-forward", false, "Open port-forwards for all services")
 	serverCmd.PersistentFlags().Bool("reverse-proxy", false, "Reverse proxy all services via 0.0.0.0 on the kubedock host as well")
 	serverCmd.PersistentFlags().Bool("pre-archive", false, "Enable support for copying single files to containers without starting them")
+	serverCmd.PersistentFlags().Bool("disable-services", false, "Disable service creation (requires a network solution such as kubedock-dns)")
 
 	viper.BindPFlag("server.listen-addr", serverCmd.PersistentFlags().Lookup("listen-addr"))
 	viper.BindPFlag("server.socket", serverCmd.PersistentFlags().Lookup("unix-socket"))
@@ -91,6 +92,7 @@ func init() {
 	viper.BindPFlag("port-forward", serverCmd.PersistentFlags().Lookup("port-forward"))
 	viper.BindPFlag("reverse-proxy", serverCmd.PersistentFlags().Lookup("reverse-proxy"))
 	viper.BindPFlag("pre-archive", serverCmd.PersistentFlags().Lookup("pre-archive"))
+	viper.BindPFlag("disable-services", serverCmd.PersistentFlags().Lookup("disable-services"))
 
 	viper.BindEnv("server.listen-addr", "SERVER_LISTEN_ADDR")
 	viper.BindEnv("server.tls-enable", "SERVER_TLS_ENABLE")

--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -262,6 +262,9 @@ func (in *instance) createServices(tainr *types.Container) error {
 // container definition.
 func (in *instance) getServices(tainr *types.Container) []corev1.Service {
 	svcs := []corev1.Service{}
+	if in.disableServices {
+		return svcs
+	}
 	ports := tainr.GetServicePorts()
 	if len(ports) == 0 {
 		// no ports available, can't create a service without ports

--- a/internal/backend/main.go
+++ b/internal/backend/main.go
@@ -48,6 +48,7 @@ type instance struct {
 	namespace         string
 	timeOut           int
 	kuburl            string
+	disableServices   bool
 }
 
 // Config is the structure to instantiate a Backend object
@@ -77,6 +78,10 @@ type Config struct {
 	// KubedockURL contains the url of this kubedock instance, to be used in
 	// docker-in-docker instances/sidecars.
 	KubedockURL string
+
+	// Disable the creation of services. A networking solution such as kubedock-dns
+	// should be used.
+	DisableServices bool
 }
 
 // New will return a Backend instance.
@@ -102,5 +107,6 @@ func New(cfg Config) (Backend, error) {
 		containerTemplate: podtemplate.ContainerFromPod(pod),
 		kuburl:            cfg.KubedockURL,
 		timeOut:           int(cfg.TimeOut.Seconds()),
+		disableServices:   cfg.DisableServices,
 	}, nil
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -98,6 +98,7 @@ func getBackend(cfg *rest.Config, cli kubernetes.Interface) (backend.Backend, er
 	timeout := viper.GetDuration("kubernetes.timeout")
 	podtmpl := viper.GetString("kubernetes.pod-template")
 	imgpsr := strings.ReplaceAll(viper.GetString("kubernetes.image-pull-secrets"), " ", "")
+	dissvcs := viper.GetBool("disable-services")
 
 	optlog := ""
 	imgps := []string{}
@@ -128,6 +129,7 @@ func getBackend(cfg *rest.Config, cli kubernetes.Interface) (backend.Backend, er
 		PodTemplate:      podtmpl,
 		KubedockURL:      kuburl,
 		TimeOut:          timeout,
+		DisableServices:  dissvcs,
 	})
 }
 


### PR DESCRIPTION
Fixes #110

This patch adds a --disable-services command-line flag to disable the creation of services. Together with the added annotations, this allows kubedock-dns to be used to run multiple test jobs at the same time in a single namespace. 