### PR TITLE
Improve stdout for multiline without newline

### DIFF
--- a/internal/util/ioproxy/ioproxy.go
+++ b/internal/util/ioproxy/ioproxy.go
@@ -65,17 +65,25 @@ func (w *IoProxy) writeAll(writer io.Writer, buf []byte) error {
 	return nil
 }
 
-// process will go through the buffer and writes chunks that end with
-// a newline to the output writer.
+// process iterates over the buffer and writes chunks that end with
+// a newline character to the output writer.
 func (w *IoProxy) process() int {
-	for pos := 0; pos < len(w.buf)-1; pos++ {
-		if w.buf[pos] == 10 { // write chunk if newline char is found
+	bufferLength := len(w.buf)
+	// Iterate over the buffer to find newline characters
+	for pos := 0; pos < bufferLength-1; pos++ {
+		if w.buf[pos] == '\n' {
 			w.write(w.buf[:pos+1])
 			w.buf = w.buf[pos+1:]
 			return pos + 1
 		}
 	}
-	return 0
+
+	// If no newline was found, write the entire buffer if not empty
+	if bufferLength > 0 {
+		w.write(w.buf)
+	}
+	w.buf = nil
+	return bufferLength
 }
 
 // write will write data to the configured writer, using the correct header.


### PR DESCRIPTION
Current implementation outputs only lines with newline.
It outputs last line without newline as output of following command.

```bash
$ podman exec -i 02d121024407 /bin/sh
echo "line1
line2
line3"
line1
line2
echo echo2
line3
echo echo3
echo2
```

For first `echo` it outputs only two lines. 
It outputs third line after second `echo`