### PR TITLE
root user id is always 0 add handling when runAs is set to "root"

### DIFF
--- a/internal/model/types/container.go
+++ b/internal/model/types/container.go
@@ -266,6 +266,12 @@ func (co *Container) GetPodSecurityContext(context *corev1.PodSecurityContext) (
 		return context, nil
 	}
 
+	// the user id for the root user is always 0
+	if user == "root" {
+		klog.Infof("user is root so setting user to 0")
+		user = "0"
+	}
+
 	if context == nil {
 		context = &corev1.PodSecurityContext{}
 	}


### PR DESCRIPTION
This PR handles the issue mentioned in https://github.com/joyrex2001/kubedock/issues/119 
The issue happens when the following `cmd.withUser("root")` is set in TestContainers.
