### PR TITLE
set kubedock.hostalias/0 to pod name rather than leaving it empty

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -71,7 +71,11 @@ func (in *instance) startContainer(tainr *types.Container) (DeployState, error) 
 	pod.ObjectMeta.Labels = in.getLabels(pod.ObjectMeta.Labels, tainr)
 	pod.ObjectMeta.Annotations = in.getAnnotations(pod.ObjectMeta.Annotations, tainr)
 
-	pod.ObjectMeta.Annotations["kubedock.hostalias/0"] = tainr.Hostname
+	if tainr.Hostname == "" {
+		pod.ObjectMeta.Annotations["kubedock.hostalias/0"] = tainr.GetPodName()
+	} else {
+		pod.ObjectMeta.Annotations["kubedock.hostalias/0"] = tainr.Hostname
+	}
 	for i, hostname := range tainr.NetworkAliases {
 		pod.ObjectMeta.Annotations[fmt.Sprintf("kubedock.hostalias/%d", i+1)] = hostname
 	}


### PR DESCRIPTION
I'm using @ErikEngerd's `kubedock-dns` and `--disable-services` 

When starting containers with `kubedock.hostalias/0` that are empty the container will fail to start (prob due to the mutating webhook if I understand it correctly)
I think it makes sense to set kubedock.hostalias/0 to the pod's name when its not set by any other means.

Let me know if this is a good fix or if you have any other suggestions.
Thanks.
-DM 