### PR TITLE
Feature - Preserve original pre archive file permissions

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -694,11 +694,13 @@ func (in *instance) createConfigMapFromFiles(tainr *types.Container, files map[s
 
 // createConfigMapFromRaw will create a configmap with given name, and adds
 // given files to it. If failed, it will return an error.
-func (in *instance) createConfigMapFromRaw(tainr *types.Container, files map[string][]byte) (*corev1.ConfigMap, error) {
+func (in *instance) createConfigMapFromRaw(tainr *types.Container, files map[string][]types.File) (*corev1.ConfigMap, error) {
 	dat := map[string][]byte{}
 	for src, d := range files {
 		klog.V(3).Infof("adding %s to configmap %s", src, tainr.ShortID)
-		dat[in.fileID(src)] = d
+		for _, file := range d {
+			dat[in.fileID(src)] = file.Data.Bytes()
+		}
 	}
 	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -576,11 +576,11 @@ func (in *instance) addPreArchives(tainr *types.Container, pod *corev1.Pod) erro
 				},
 				Items: func() []corev1.KeyToPath {
 					items := []corev1.KeyToPath{}
-					for file := range pfiles {
+					for file, FileInfo := range pfiles {
 						items = append(items, corev1.KeyToPath{
 							Key:  in.fileID(file),
 							Path: filepath.Base(file),
-							Mode: func(i int32) *int32 { return &i }(0755), // THIS FILE MODESET VALUE NEEDS TO BE PULLED FROM THE ORIGINAL FILE
+							Mode: func(i int32) *int32 { return &i }(int32(FileInfo[0].FileMode)),
 						})
 					}
 					return items

--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -576,11 +576,11 @@ func (in *instance) addPreArchives(tainr *types.Container, pod *corev1.Pod) erro
 				},
 				Items: func() []corev1.KeyToPath {
 					items := []corev1.KeyToPath{}
-					for file, FileInfo := range pfiles {
+					for file, info := range pfiles {
 						items = append(items, corev1.KeyToPath{
 							Key:  in.fileID(file),
 							Path: filepath.Base(file),
-							Mode: func(i int32) *int32 { return &i }(int32(FileInfo[0].FileMode)),
+							Mode: func(i int32) *int32 { return &i }(int32(info[0].FileMode)),
 						})
 					}
 					return items

--- a/internal/model/types/container.go
+++ b/internal/model/types/container.go
@@ -460,14 +460,14 @@ func (co *Container) GetPreArchiveFiles() map[string][]File {
 			klog.Errorf("error extracting %s from archive: %s", fls[0], err)
 			continue
 		}
-		fileMode, err := tar.GetFileMode(pa.Path, fls[0], bytes.NewReader(pa.Archive))
+		mode, err := tar.GetFileMode(pa.Path, fls[0], bytes.NewReader(pa.Archive))
 		if err != nil {
-			klog.Errorf("error getting %s file mode from archive: %s", fileMode, err)
+			klog.Errorf("error getting %s file mode from archive: %s", mode, err)
 			continue
 		}
 
-		files[fls[0]] = []File{{FileMode: fileMode, Data: dat}}
-		klog.Infof("File mode for %s is: %o\n", fls[0], fileMode)
+		files[fls[0]] = []File{{FileMode: mode, Data: dat}}
+		klog.Infof("File mode for %s is: %o\n", fls[0], mode)
 	}
 	return files
 }

--- a/internal/model/types/container.go
+++ b/internal/model/types/container.go
@@ -444,8 +444,8 @@ func (co *Container) HasDockerSockBinding() bool {
 
 // GetPreArchiveFiles will return all single files from the pre-archives as
 // a map with the filename as key, and the actual file contents as value.
-func (co *Container) GetPreArchiveFiles() map[string][]byte {
-	files := map[string][]byte{}
+func (co *Container) GetPreArchiveFiles() map[string][]File {
+	files := map[string][]File{}
 	for _, pa := range co.PreArchives {
 		fls, err := tar.GetTargetFileNames(pa.Path, bytes.NewReader(pa.Archive))
 		if err != nil {
@@ -460,7 +460,14 @@ func (co *Container) GetPreArchiveFiles() map[string][]byte {
 			klog.Errorf("error extracting %s from archive: %s", fls[0], err)
 			continue
 		}
-		files[fls[0]] = dat.Bytes()
+		fileMode, err := tar.GetFileMode(pa.Path, fls[0], bytes.NewReader(pa.Archive))
+		if err != nil {
+			klog.Errorf("error getting %s file mode from archive: %s", fileMode, err)
+			continue
+		}
+
+		files[fls[0]] = []File{{FileMode: fileMode, Data: dat}}
+		klog.Infof("File mode for %s is: %o\n", fls[0], fileMode)
 	}
 	return files
 }

--- a/internal/model/types/file.go
+++ b/internal/model/types/file.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+	"bytes"
+	"os"
+)
+
+type File struct {
+	FileMode os.FileMode
+	Data     bytes.Buffer
+}

--- a/internal/model/types/file.go
+++ b/internal/model/types/file.go
@@ -5,6 +5,7 @@ import (
 	"os"
 )
 
+// File describes the details of a file (content and mode).
 type File struct {
 	FileMode os.FileMode
 	Data     bytes.Buffer

--- a/internal/util/tar/tar.go
+++ b/internal/util/tar/tar.go
@@ -86,6 +86,24 @@ func GetTargetFileNames(dst string, archive io.Reader) ([]string, error) {
 	return getTargets(dst, archive, tar.TypeReg)
 }
 
+// GetFileMode will return the file mode permissions of the given file in 
+// the archive.
+func GetFileMode(dst string, fname string, archive io.Reader) (os.FileMode, error) {
+	tr, err := NewReader(archive)
+	if err != nil {
+		return 0, err
+	}
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			return 0, err
+		}
+		if header != nil && filepath.Join(dst, header.Name) == fname {
+			return header.FileInfo().Mode(), nil
+		}
+	}
+}
+
 // getTargets will return all given asset names of type (dir/file).
 func getTargets(dst string, archive io.Reader, typ byte) ([]string, error) {
 	res := []string{}

--- a/internal/util/tar/tar_test.go
+++ b/internal/util/tar/tar_test.go
@@ -38,11 +38,11 @@ func TestPackFolder(t *testing.T) {
 		t.Error("expected archive to contain .")
 	}
 
-	fileMode, err := GetFileMode("", "tar_test.go", bytes.NewReader(dat))
+	mode, err := GetFileMode("", "tar_test.go", bytes.NewReader(dat))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
-	if fileMode == 0 {
+	if mode == 0 {
 		t.Error("expected archive to contain tar_test.go with valid file mode")
 	}
 

--- a/internal/util/tar/tar_test.go
+++ b/internal/util/tar/tar_test.go
@@ -38,6 +38,14 @@ func TestPackFolder(t *testing.T) {
 		t.Error("expected archive to contain .")
 	}
 
+	fileMode, err := GetFileMode("", "tar_test.go", bytes.NewReader(dat))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if fileMode == 0 {
+		t.Error("expected archive to contain tar_test.go with valid file mode")
+	}
+
 	rsz := len(dat)
 	csz, err := GetTarSize(append(dat, []byte{0, 0, 0, 0}...))
 	if err != nil {


### PR DESCRIPTION
This is a work in progress PR that refactor the code to use allow for indevidual file permissions by using indevidual items in the config map.

@joyrex2001 I'm still relatively new to GO and would appreciate any feedback and code review.

Also I'm still trying to figure out how to to determine the original file permissions in the contest of `addPreArchives` any point in the right direction would be appriciated.

P.S - I will remove WIP from this PR when I feel like it is ready to be merged.

-DM 