### PR TITLE
Fix Network Assignment

### DIFF
--- a/internal/server/routes/docker/containers.go
+++ b/internal/server/routes/docker/containers.go
@@ -71,6 +71,17 @@ func ContainerCreate(cr *common.ContextRouter, c *gin.Context) {
 			}
 		}
 	}
+	
+	net := in.HostConfig.NetworkMode
+	if net != "" && net != "default" {
+		klog.V(5).Infof("NetworkMode != '', connecting container to network: %s", net)
+		netw, err := cr.DB.GetNetworkByName(net)
+		if err != nil {
+			httputil.Error(c, http.StatusInternalServerError, err)
+			return
+		}
+		tainr.ConnectNetwork(netw.ID)
+	}
 
 	for _, endp := range in.NetworkConfig.EndpointsConfig {
 		addNetworkAliases(tainr, endp)

--- a/internal/server/routes/docker/types.go
+++ b/internal/server/routes/docker/types.go
@@ -41,8 +41,9 @@ type HostConfig struct {
 	Binds        []string `json:"Binds"`
 	Mounts       []Mount  `json:"Mounts"`
 	PortBindings map[string][]PortBinding
-	Memory       int `json:"Memory"`
-	NanoCpus     int `json:"NanoCpus"`
+	Memory       int    `json:"Memory"`
+	NanoCpus     int    `json:"NanoCpus"`
+	NetworkMode  string `json:"NetworkMode"`
 }
 
 // PortBinding represents a binding between to a port


### PR DESCRIPTION
Hi Everyone, 

As specified in issue https://github.com/joyrex2001/kubedock/issues/131 when a specific network is specified KubeDock doesnt assign the container to the specified network.

This fix aim to resolve this issue.
Based on my testing containers where a network is not specified are handled as before and when a network is specified the containers are assigned to the specified network 

As always code review and feedback would be much appreciated.
Thank you.
-DM 