### PR TITLE
Allows Network Assignment by NetworkName or NetworkID

### DIFF
--- a/internal/server/routes/docker/containers.go
+++ b/internal/server/routes/docker/containers.go
@@ -75,7 +75,7 @@ func ContainerCreate(cr *common.ContextRouter, c *gin.Context) {
 	net := in.HostConfig.NetworkMode
 	if net != "" && net != "default" {
 		klog.V(5).Infof("NetworkMode != '', connecting container to network: %s", net)
-		netw, err := cr.DB.GetNetworkByName(net)
+		netw, err := cr.DB.GetNetworkByNameOrID(net)
 		if err != nil {
 			httputil.Error(c, http.StatusInternalServerError, err)
 			return


### PR DESCRIPTION
The docker api allows the usage of Network Name or Network ID so this PR fixes my earlier PR that only allows the usage of Network Name.

I apologize for the PR duplication.

Thanks.
-DM 