### PR TITLE
ci: Adds PR title check

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,14 @@
+{
+  "LABEL": {
+    "name": "title needs formatting",
+    "color": "EEEEEE"
+  },
+  "CHECKS": {
+    "regexp": "^(feat|perf|fix|hotfix|bug|docs|test|revert|refactor|ci|build|chore)!?(\\(.*\\))?!?:.*"
+  },
+  "MESSAGES": {
+    "success": "PR title is valid",
+    "failure": "PR title is invalid",
+    "notice": "PR Title needs to pass regex '^(feat|perf|fix|hotfix|bug|docs|test|revert|refactor|ci|build|chore)!?(\\(.*\\))?!?:.*"
+  }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,28 @@
+name: "PR title check"
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+# IMPORTANT: No checkout actions, scripts, or builds should be added to this workflow. Permissions should always be used
+# with extreme caution. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+permissions: {}
+
+# PR updates can happen in quick succession leading to this
+# workflow being trigger a number of times. This limits it
+# to one run per PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    permissions:
+      contents: read
+      pull-requests: read
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # v1.4.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

As described in #147 a PR title check workflow would help in generating release notes based on standardized PR titles.
This is a rather simple implementation of that. Inspired by other OSS project's I've worked on.

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [x] Other (please describe): Ci related

## What is the current behavior?

PR titles are not checked

## What is the new behavior?

PR titles are validated against the config. They should match [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). If not, the CI fails. 

## Other information

In order for this to have value, @joyrex2001 this should become a required succeeded CI step.