### PR TITLE
ci: Fix release drafter config path

### DIFF
--- a/.github/workflows/update-draft-release.yml
+++ b/.github/workflows/update-draft-release.yml
@@ -23,6 +23,6 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         with:
-          config-name: .github/release-drafter-config.yml
+          config-name: release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Fixes release draft config path as that by default searches in the `.github` folder

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [x] Other (please describe): CI related changes

## What is the current behavior?

ReleaseDrafter errors as the config-file can't be found.

## What is the new behavior?

ReleaseDrafter shouldn't error anymore.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->