### PR TITLE
ci: Image build optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,26 +2,34 @@
 ## Build kubedock ## ----------------------------------------------------------
 ####################
 
-FROM docker.io/golang:1.25 AS kubedock
+FROM docker.io/golang:1.25 AS build
 
 ARG CODE=github.com/joyrex2001/kubedock
 
-ADD . /go/src/${CODE}/
-RUN cd /go/src/${CODE} \
-    && make test build \
+WORKDIR /go/src/${CODE}
+
+# Updates ca-certificates for the `inspector` command to connect to dockerhub etc.
+RUN update-ca-certificates
+
+# Create a cached layer for the dependencies
+COPY go.* .
+RUN go mod download
+
+# Copy all other files
+COPY . .
+RUN make test build \
     && mkdir /app \
-    && cp kubedock /app
+    && cp kubedock /app/
 
 #################
 ## Final image ## ------------------------------------------------------------
 #################
 
-FROM alpine:3
+FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-RUN apk add --no-cache ca-certificates \
-    && update-ca-certificates
-
-COPY --from=kubedock /app /usr/local/bin
+# Copy the compiled binary from the builder stage
+COPY --from=build /app/kubedock /usr/local/bin/kubedock
 
 ENTRYPOINT ["/usr/local/bin/kubedock"]
 CMD [ "server" ]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
-VERSION=$$(git describe --tags 2>/dev/null || echo 'latest') 
-LDFLAGS="-X github.com/joyrex2001/kubedock/internal/config.Date=`date -u +%Y%m%d-%H%M%S`  \
-         -X github.com/joyrex2001/kubedock/internal/config.Build=`git rev-list -1 HEAD`   \
-         -X github.com/joyrex2001/kubedock/internal/config.Version=$(VERSION) \
-         -X github.com/joyrex2001/kubedock/internal/config.Image=joyrex2001/kubedock:$(VERSION)"
+VERSION := $(shell git describe --tags 2>/dev/null || echo 'latest')
+DATE := $(shell date -u +%Y%m%d-%H%M%S)
+COMMIT := $(shell git rev-list -1 HEAD)
+
+LDFLAGS := "-s -w \
+	-X github.com/joyrex2001/kubedock/internal/config.Date=$(DATE) \
+	-X github.com/joyrex2001/kubedock/internal/config.Build=$(COMMIT) \
+	-X github.com/joyrex2001/kubedock/internal/config.Version=$(VERSION) \
+	-X github.com/joyrex2001/kubedock/internal/config.Image=joyrex2001/kubedock:$(VERSION)"
 
 run:
 	CGO_ENABLED=0 go run main.go server -P -v 2 --port-forward
 
 build:
-	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o kubedock
+	CGO_ENABLED=0 go build -trimpath -ldflags $(LDFLAGS) -o kubedock
 
 gox:
 	CGO_ENABLED=0 gox -os="linux darwin windows" -arch="amd64" \


### PR DESCRIPTION
# Description

Image build optimizations

Fixes: #159

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [x] Other (please describe): Build optimizations

## What is the current behavior?

Image build using Alpine

## What is the new behavior?

* Image build on scratch
* Image run using `nonroot` user
* Binary size optimized by setting `-s -w` flags
* Use `:=` with `$(shell ...)` instead of `$$()` to evaluate once at Make parse time. 

## Other information

Image size reduced from 65mb --> 40mb
Packages reduced from 136 --> 116

Will provide a follow-up for further optimization as I believe for example make test shouldn't be part of image build.