### PR TITLE
fix: Labels for feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/02_FEATURE_REQUEST.md
@@ -2,7 +2,7 @@
 name: "\U0001F680 Feature Request"
 about: "I have a suggestion (and may want to implement it \U0001F642)!"
 title: "feat: "
-labels: 'i: enhancement, i: needs triage'
+labels: 'enhancement, needs triage'
 
 ---
 


### PR DESCRIPTION
# Description

Fixes labels added to a feature request template

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [x] Other (please describe):

## What is the current behavior?

Labels are not added to issues created using the issue template for feature requests

## What is the new behavior?

Labels should be added to newly created feature requests

## Other information

Please add: `skip-changelog` label as this is irrelevant.