### PR TITLE
fix: Use busybox to fix init-container copying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN make test build \
 ## Final image ## ------------------------------------------------------------
 #################
 
-FROM scratch
+FROM docker.io/busybox:latest
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy the compiled binary from the builder stage


### PR DESCRIPTION
# Description

Use busybox base image instead of scratch to allow init-containers to use shell commands.

Fixes: #183

Please check the type of change your PR introduces:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [ ] Other (please describe):