### PR TITLE
feat: improve filter `Match` logic to match Mobys, add regexp support…

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -65,13 +65,13 @@ func (e *instance) Unsubscribe(id string) {
 }
 
 // Match will match given event filter conditions.
-func (m *Message) Match(typ string, key string, val string) bool {
+func (m *Message) Match(typ string, key string, val string) (bool, error) {
 	klog.V(5).Infof("match %s: %s = %s", typ, key, val)
 	if typ == Type {
-		return m.Type == key
+		return m.Type == key, nil
 	}
 	if m.Type == typ {
-		return m.ID == key
+		return m.ID == key, nil
 	}
-	return true
+	return true, nil
 }

--- a/internal/model/types/container.go
+++ b/internal/model/types/container.go
@@ -539,18 +539,34 @@ func (co *Container) DisconnectNetwork(id string) error {
 }
 
 // Match will match given type with given key value pair.
-func (co *Container) Match(typ string, key string, val string) bool {
+func (co *Container) Match(typ string, key string, val string) (bool, error) {
 	if typ == "name" {
-		return co.Name == key
+		return co.nameMatch(key)
 	}
 	if typ != "label" {
-		return true
+		return true, nil
 	}
 	v, ok := co.Labels[key]
 	if !ok {
-		return false
+		return false, nil
 	}
-	return v == val
+	return v == val, nil
+}
+
+func (co *Container) nameMatch(key string) (bool, error) {
+	// Fast path, exact match
+	if co.Name == key {
+		return true, nil
+	}
+	// Fallback to regexp
+	match, err := regexp.MatchString(key, co.Name)
+	if err != nil {
+		return false, err
+	}
+	if match {
+		return true, nil
+	}
+	return false, nil
 }
 
 // StateString returns a string that describes the state.

--- a/internal/model/types/container_test.go
+++ b/internal/model/types/container_test.go
@@ -863,10 +863,36 @@ func TestMatch(t *testing.T) {
 			val:    "",
 			match:  true,
 		},
+		{
+			name:   "testymctestface",
+			labels: map[string]string{"some": "what"},
+			typ:    "name",
+			key:    "^testymctestface$", // Full name regex match
+			val:    "",
+			match:  true,
+		},
+		{
+			name:   "testymctestface",
+			labels: map[string]string{"some": "what"},
+			typ:    "name",
+			key:    "mctest", // Partial regex match
+			val:    "",
+			match:  true,
+		},
+		{
+			name:   "testymctestface",
+			labels: map[string]string{"some": "what"},
+			typ:    "name",
+			key:    "^nomatch$",
+			val:    "",
+			match:  false,
+		},
 	}
 	for i, tst := range tests {
 		in := &Container{Labels: tst.labels, Name: tst.name}
-		if in.Match(tst.typ, tst.key, tst.val) != tst.match {
+		if isMatch, err := in.Match(tst.typ, tst.key, tst.val); err != nil {
+			t.Errorf("failed test %d, with unexpected error: %v", i, err)
+		} else if isMatch != tst.match {
 			t.Errorf("failed test %d - match %v", i, tst.match)
 		}
 	}

--- a/internal/model/types/network.go
+++ b/internal/model/types/network.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"regexp"
 	"time"
 )
 
@@ -19,16 +20,32 @@ func (nw *Network) IsPredefined() bool {
 }
 
 // Match will match given type with given key value pair.
-func (nw *Network) Match(typ string, key string, val string) bool {
+func (nw *Network) Match(typ string, key string, val string) (bool, error) {
 	if typ == "name" {
-		return nw.Name == key
+		return nw.nameMatch(key)
 	}
 	if typ != "label" {
-		return true
+		return true, nil
 	}
 	v, ok := nw.Labels[key]
 	if !ok {
-		return false
+		return false, nil
 	}
-	return v == val
+	return v == val, nil
+}
+
+func (nw *Network) nameMatch(key string) (bool, error) {
+	// Fast path, exact match
+	if nw.Name == key {
+		return true, nil
+	}
+	// Fallback to regexp
+	match, err := regexp.MatchString(key, nw.Name)
+	if err != nil {
+		return false, err
+	}
+	if match {
+		return true, nil
+	}
+	return false, nil
 }

--- a/internal/server/filter/filter_test.go
+++ b/internal/server/filter/filter_test.go
@@ -8,8 +8,8 @@ type matcher struct {
 	res bool
 }
 
-func (m *matcher) Match(t, k, v string) bool {
-	return m.res
+func (m *matcher) Match(t string, k string, v string) (bool, error) {
+	return m.res, nil
 }
 
 func TestFilter(t *testing.T) {


### PR DESCRIPTION
… on name type filter in container and network filters

# Description

This PR improves the filter matching logic to align with Docker/Moby's behavior and adds regular expression support for name-based filtering on containers and networks.

Key changes:
- Updated `Match` method signature to return `(bool, error)` to handle regex errors
- Added regex support for container and network name filters with fallback from exact match
- Improved filter matching logic to OR results within each filter type and AND across filter types (matching Moby's implementation)
- Added test cases for regex name matching


Fixes: # (issue)

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## What is the current behavior?

- Container and network name filtering only supports exact string matching
- The filter matching logic doesn't follow Moby's pattern, potentially returning incorrect results when multiple filters of different types are used


## What is the new behavior?

- Container and network name filters now support regular expressions in addition to exact matching
  - Fast path: exact string match is tried first for performance
  - Fallback: if exact match fails, regex pattern matching is attempted
- Filter matching logic now properly implements Moby's approach:
  - OR logic within each filter type (e.g., multiple name filters)
  - AND logic across different filter types (e.g., name AND label filters)
- `Match` method now returns `(bool, error)` to properly handle and propagate regex errors
- Erroneous filter patterns are ignored following Moby's pattern


## Other information

Example usage:
- Exact match: `name=testymctestface` (works as before)
- Regex match: `name=^testymctestface$` (full name match)
- Partial regex: `name=mctest` (matches any container with "mctest" in the name)

Test coverage includes new test cases validating regex matching behavior for both successful matches and non-matches.
