### PR TITLE
chore: upgrade go from 1.25.3 to 1.25.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.25.3'
+  GOLANG_VERSION: '1.25.5'
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.25.3'
+  GOLANG_VERSION: '1.25.5'
   
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joyrex2001/kubedock
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/containers/image/v5 v5.36.2


### PR DESCRIPTION
# Description

Upgrade Go version to fix CVE

Fixes: CVE **[CVE-2025-61729](https://ubuntu.com/security/CVE-2025-61729)**

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)

## What is the current behavior?

There is a CVE : **[CVE-2025-61729](https://ubuntu.com/security/CVE-2025-61729)**

## What is the new behavior?

There is no CVE

## Other information
