### PR TITLE
chore: upgrade go from 1.25.5 to 1.25.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.25.5'
+  GOLANG_VERSION: '1.25.9'
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   # Golang version to use across CI steps
-  GOLANG_VERSION: '1.25.5'
+  GOLANG_VERSION: '1.25.9'
   
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joyrex2001/kubedock
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/containers/image/v5 v5.36.2


### PR DESCRIPTION
# Description

Upgrade go version to fix [CVE-2025-68121 ](https://avd.aquasec.com/nvd/2025/cve-2025-68121/)

Fixes: # (issue)

## Type of change

Chore


- [x] Bugfix (non-breaking change which fixes an issue)

## What is the current behavior?

There is a CVE

## What is the new behavior?

There is no CVE
