### PR TITLE
fix: Fix key only matching on labels

### DIFF
--- a/internal/model/types/container.go
+++ b/internal/model/types/container.go
@@ -550,6 +550,9 @@ func (co *Container) Match(typ string, key string, val string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
+	if val == "" {
+		return true, nil
+	}
 	return v == val, nil
 }
 

--- a/internal/model/types/container_test.go
+++ b/internal/model/types/container_test.go
@@ -887,6 +887,14 @@ func TestMatch(t *testing.T) {
 			val:    "",
 			match:  false,
 		},
+		{
+			name:   "testymctestface",
+			labels: map[string]string{"com.docker.compose.config-hash": "2107007e-b7c8-df23-18fb-6a6f79726578"},
+			typ:    "label",
+			key:    "com.docker.compose.config-hash",
+			val:    "",
+			match:  true,
+		},
 	}
 	for i, tst := range tests {
 		in := &Container{Labels: tst.labels, Name: tst.name}


### PR DESCRIPTION
# Description

This PR implements key only matches on labels.

Fixes: #245

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## What is the current behavior?

Label matches that don't specify a value will not match.

## What is the new behavior?

Label matches that don't specify a value will match if the key is present.
