### PR TITLE
fix: Fixing file paths when working with Windows

### DIFF
--- a/internal/backend/deploy.go
+++ b/internal/backend/deploy.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -596,7 +596,7 @@ func (in *instance) addPreArchives(tainr *types.Container, pod *corev1.Pod) erro
 					for file, info := range pfiles {
 						items = append(items, corev1.KeyToPath{
 							Key:  in.fileID(file),
-							Path: filepath.Base(file),
+							Path: path.Base(file),
 							Mode: func(i int32) *int32 { return &i }(int32(info[0].FileMode)),
 						})
 					}
@@ -608,7 +608,7 @@ func (in *instance) addPreArchives(tainr *types.Container, pod *corev1.Pod) erro
 			mounts = append(mounts, corev1.VolumeMount{
 				Name:      "pfiles",
 				MountPath: dst,
-				SubPath:   filepath.Base(dst),
+				SubPath:   path.Base(dst),
 			})
 		}
 	}

--- a/internal/util/tar/tar.go
+++ b/internal/util/tar/tar.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 
 	"k8s.io/klog"
@@ -81,7 +82,7 @@ func UnpackFile(dst, fname string, archive io.Reader, dest io.Writer) error {
 		if err != nil {
 			return err
 		}
-		if header != nil && filepath.Join(dst, header.Name) == fname {
+		if header != nil && path.Join(dst, header.Name) == fname {
 			_, err = io.Copy(dest, tr)
 			return err
 		}
@@ -112,7 +113,7 @@ func GetFileMode(dst string, fname string, archive io.Reader) (os.FileMode, erro
 		if err != nil {
 			return 0, err
 		}
-		if header != nil && filepath.Join(dst, header.Name) == fname {
+		if header != nil && path.Join(dst, header.Name) == fname {
 			return header.FileInfo().Mode(), nil
 		}
 	}
@@ -135,7 +136,7 @@ func getTargets(dst string, archive io.Reader, typ byte) ([]string, error) {
 		case header == nil:
 			continue
 		}
-		target := filepath.Join(dst, header.Name)
+		target := path.Join(dst, header.Name)
 		if header.Typeflag == typ {
 			res = append(res, target)
 		}

--- a/internal/util/tar/tar_test.go
+++ b/internal/util/tar/tar_test.go
@@ -1,11 +1,78 @@
 package tar
 
 import (
+	"archive/tar"
 	"bufio"
 	"bytes"
 	"slices"
+	"strings"
 	"testing"
 )
+
+// singleFileArchive creates an in-memory tar archive containing a single
+// regular file with the given name and contents.
+func singleFileArchive(t *testing.T, name, contents string) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	tw := tar.NewWriter(&b)
+	hdr := &tar.Header{
+		Name:     name,
+		Mode:     0644,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatalf("unexpected error writing header: %s", err)
+	}
+	if _, err := tw.Write([]byte(contents)); err != nil {
+		t.Fatalf("unexpected error writing contents: %s", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("unexpected error closing archive: %s", err)
+	}
+	return b.Bytes()
+}
+
+// TestContainerPathsUseForwardSlash is a regression test for running kubedock
+// on Windows. The dst is a container (linux) path and tar entry names are
+// always forward-slash, so joining them must use POSIX separators regardless
+// of the host OS. Previously path/filepath was used, which produced
+// backslashes on Windows (e.g. \opt\keycloak\data\import\realm-export.json)
+// and resulted in invalid container mount paths.
+func TestContainerPathsUseForwardSlash(t *testing.T) {
+	const dst = "/opt/keycloak/data/import"
+	const file = "realm-export.json"
+	const want = "/opt/keycloak/data/import/realm-export.json"
+
+	dat := singleFileArchive(t, file, "{}")
+
+	files, err := GetTargetFileNames(dst, bytes.NewReader(dat))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(files) != 1 || files[0] != want {
+		t.Errorf("GetTargetFileNames returned %v, expected [%s]", files, want)
+	}
+	if strings.ContainsRune(files[0], '\\') {
+		t.Errorf("target path %q contains a backslash; container paths must use forward slashes", files[0])
+	}
+
+	mode, err := GetFileMode(dst, want, bytes.NewReader(dat))
+	if err != nil {
+		t.Fatalf("unexpected error from GetFileMode: %s", err)
+	}
+	if mode == 0 {
+		t.Error("expected a valid file mode")
+	}
+
+	var out bytes.Buffer
+	if err := UnpackFile(dst, want, bytes.NewReader(dat), &out); err != nil {
+		t.Fatalf("unexpected error from UnpackFile: %s", err)
+	}
+	if out.String() != "{}" {
+		t.Errorf("UnpackFile returned %q, expected %q", out.String(), "{}")
+	}
+}
 
 func TestPackFolder(t *testing.T) {
 	var b bytes.Buffer


### PR DESCRIPTION
# Description

Make use of the library path instead of filpath so the forward slash is not being transformed to a backslash on Windows machines.
Added a testcase to prove the fix, the testcase only fails when ran on Windows machines, see the new behavior section

Fixes: # (issue)

## Type of change

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] This change requires a documentation update
- [ ] Other (please describe):

## What is the current behavior?

Running on plain Windows (no WSL) a volumemount path like /opt/keycloak/data/import is being transformed to \opt\keycloak\data\import which makes it an invalid volumemount.
This happens when running a testcontainer and use .withRealmImportFile or .withFileSystemBind

## What is the new behavior?

Now running on Windows also gives a valid volumemount path

Running the test before applying the fix:
<img width="2586" height="450" alt="Running new test without the fix" src="https://github.com/user-attachments/assets/d2e6e1ba-f813-4134-bb3e-fcf05fa3e150" />

Running the test after applying the fix:
<img width="1422" height="420" alt="Running new test after the fix" src="https://github.com/user-attachments/assets/b121a2aa-cbe1-4726-aeac-cbdc822d1d45" />

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->